### PR TITLE
Smarty3 changes internal var names - fixing

### DIFF
--- a/engine/include/CPage.php
+++ b/engine/include/CPage.php
@@ -218,8 +218,8 @@ class CPage extends CRequest{
      * @return variable value or null if the variable is undefined
 	 */
 	function get($name){
-		if (isset($this->template->_tpl_vars[$name])) {
-            return $this->template->_tpl_vars[$name];
+		if (isset($this->template->tpl_vars[$name])) {
+            return $this->template->tpl_vars[$name];
         } else {
             return null;
         }


### PR DESCRIPTION
Smarty's developer changes internal property name from _tpl_vars to tpl_var. CPage->get() didn't work after this.