### PR TITLE
fatal errors should be logged as default

### DIFF
--- a/docker/www/php.ini
+++ b/docker/www/php.ini
@@ -1,4 +1,5 @@
 [PHP]
+log_errors = 1
 upload_max_filesize = 30M
 post_max_size = 30M
 memory_limit = 2048M


### PR DESCRIPTION
because of this not all errors was reported to system log