### PR TITLE
Docker config fix

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -21,7 +21,7 @@ services:
        - "7080:80"
       depends_on:
        - db
-    liuqibase:
+    liquibase:
       build: ./docker/liquibase
       links:
       - db

--- a/docker/liquibase/Dockerfile
+++ b/docker/liquibase/Dockerfile
@@ -3,7 +3,7 @@ FROM openjdk:8
 WORKDIR /workdir
 
 RUN apt-get install unzip -y
-RUN apt-get update && apt-get install -y netcat
+RUN apt-get update && apt-get install -y 
 
 RUN wget https://github.com/liquibase/liquibase/releases/download/liquibase-parent-3.5.5/liquibase-3.5.5-bin.tar.gz
 RUN tar -xvf liquibase-3.5.5-bin.tar.gz

--- a/docker/liquibase/run.sh
+++ b/docker/liquibase/run.sh
@@ -1,10 +1,11 @@
 #!/bin/bash
 
-while [ "`nc -vz db 3306 2>&1 | grep open -o`" != "open" ]
-do
-    nc -vz db 3306 2>&1
-    echo "waiting for db .."
-    sleep 1
-done
+# Wait or database server is up
+# exit after one hour anyway
+export TIMEOUT=3600
+# DB server name and port
+export HOST="db"
+export PORT=3306
+timeout $TIMEOUT bash -c 'until printf "" 2>>/dev/null >>/dev/tcp/$0/$1; do echo "waiting for db .."; sleep 1; done' $HOST $PORT
 
 java -jar liquibase.jar --changeLogFile database/inforex-v1.0-changelog.sql update

--- a/docker/www/Dockerfile
+++ b/docker/www/Dockerfile
@@ -1,7 +1,7 @@
 FROM php:5.6-apache as php-base
 
 RUN apt-get update -y && apt-get upgrade -y
-RUN apt-get install software-properties-common wget -y
+RUN apt-get install software-properties-common wget less -y
 RUN apt-get install vim p7zip-full libpng-dev -y
 
 # Workaround for write permission on write to MacOS X volumes
@@ -21,6 +21,7 @@ RUN a2enmod expires
 RUN apt-get install libmcrypt-dev zlib1g zlib1g-dev -y \
 	&& docker-php-ext-install mcrypt \
 	&& docker-php-ext-install mysql \
+        && docker-php-ext-install mysqli \
 	&& docker-php-ext-install zip \
 	&& docker-php-ext-install gd \
 	&& apt-get install re2c -y


### PR DESCRIPTION
After update software in liquibase container, new version of netcat changed content of message for successfull connect to open port. Because of this, while loop, in run.sh script never ends, and loading liquibase updates, will be never processed. Liquibase container never stops.
  This fix solve this. Never use netcat for this again.
Also added mysqli php extension to modules loaded to www container - for test work with mysqli phptype driver.